### PR TITLE
Add contact event API

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,14 @@
+# Unreleased
+
+### Added
+- Add contact event API.
+
+### Changed
+
+### Removed
+
+[#6]: https://github.com/AndreaCatania/amethyst_physics/pull/6
+
 # Version 0.1.0
 
 ### Added

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -3,12 +3,12 @@
 pub use crate::{
     objects::{
         CollisionGroup, PhysicsAreaTag, PhysicsAttachment, PhysicsGarbageCollector, PhysicsHandle,
-        PhysicsJointTag, PhysicsRigidBodyTag, PhysicsShapeTag, PhysicsTag
+        PhysicsJointTag, PhysicsRigidBodyTag, PhysicsShapeTag, PhysicsTag,
     },
     servers::{
-        AreaPhysicsServerTrait, BodyMode, JointDesc, JointPhysicsServerTrait, JointPosition,
-        OverlapEvent, PhysicsWorld, RBodyPhysicsServerTrait, RigidBodyDesc, ShapeDesc,
-        ShapePhysicsServerTrait, WorldPhysicsServerTrait, ContactEvent
+        AreaPhysicsServerTrait, BodyMode, ContactEvent, JointDesc, JointPhysicsServerTrait,
+        JointPosition, OverlapEvent, PhysicsWorld, RBodyPhysicsServerTrait, RigidBodyDesc,
+        ShapeDesc, ShapePhysicsServerTrait, WorldPhysicsServerTrait,
     },
     PhysicsTime,
 };

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -3,12 +3,12 @@
 pub use crate::{
     objects::{
         CollisionGroup, PhysicsAreaTag, PhysicsAttachment, PhysicsGarbageCollector, PhysicsHandle,
-        PhysicsJointTag, PhysicsRigidBodyTag, PhysicsShapeTag, PhysicsTag,
+        PhysicsJointTag, PhysicsRigidBodyTag, PhysicsShapeTag, PhysicsTag
     },
     servers::{
         AreaPhysicsServerTrait, BodyMode, JointDesc, JointPhysicsServerTrait, JointPosition,
         OverlapEvent, PhysicsWorld, RBodyPhysicsServerTrait, RigidBodyDesc, ShapeDesc,
-        ShapePhysicsServerTrait, WorldPhysicsServerTrait,
+        ShapePhysicsServerTrait, WorldPhysicsServerTrait, ContactEvent
     },
     PhysicsTime,
 };

--- a/src/servers/body_server.rs
+++ b/src/servers/body_server.rs
@@ -1,5 +1,5 @@
 use amethyst_core::ecs::Entity;
-use amethyst_core::math::{convert, one, Point3, Unit, zero, Isometry3, Vector3};
+use amethyst_core::math::{convert, one, zero, Isometry3, Point3, Unit, Vector3};
 
 use crate::objects::*;
 
@@ -246,21 +246,21 @@ pub struct ContactEvent<N: crate::PtReal> {
     /// The other body entity.
     pub other_entity: Option<Entity>,
     /// The contact normal on the local body.
-    pub contact_normal: Unit<Vector3<N>>,
+    pub normal: Unit<Vector3<N>>,
     /// The contact location in world space.
-    pub contact_location: Point3<N>,
+    pub location: Point3<N>,
     /// The generated impulse.
-    pub contact_impulse: Vector3<N>,
+    pub impulse: Vector3<N>,
 }
 
-impl<N: crate::PtReal> Default for ContactEvent<N>{
-    fn default() -> Self{
+impl<N: crate::PtReal> Default for ContactEvent<N> {
+    fn default() -> Self {
         ContactEvent {
             other_body: PhysicsRigidBodyTag::U32(0),
             other_entity: None,
-            contact_normal: Vector3::y_axis(),
-            contact_location: Point3::origin(),
-            contact_impulse: Vector3::zeros(),
+            normal: Vector3::y_axis(),
+            location: Point3::origin(),
+            impulse: Vector3::zeros(),
         }
     }
 }

--- a/src/servers/body_server.rs
+++ b/src/servers/body_server.rs
@@ -132,6 +132,24 @@ pub trait RBodyPhysicsServerTrait<N: crate::PtReal> {
         body: PhysicsRigidBodyTag,
         position: &Vector3<N>,
     ) -> Vector3<N>;
+
+    /// Sets the maximum contact to track for this body.
+    ///
+    /// If the provided size is lower than the actual contacts that a body generate
+    /// you will lost some information; make sure to set a proper value.
+    /// The contact event are not guaranteed to arrive always in the same order.
+    ///
+    /// Default is 0.
+    fn set_max_contacts_count(&self, body_tag: PhysicsRigidBodyTag, max_contacts: usize);
+
+    /// Get the maximum contacts count of this body.
+    fn max_contacts_count(&self, body_tag: PhysicsRigidBodyTag) -> usize;
+
+    /// Fills the contacts array with the contacts events occurred in the last step.
+    /// It doesn't fill more than the `max_contact_count` set.
+    ///
+    /// It's mandatory to check this array each sub step to be sure to not miss any event.
+    fn contact_events(&self, body_tag: PhysicsRigidBodyTag, contacts: &mut Vec<ContactEvent<N>>);
 }
 
 /// This structure holds all information about the Rigid body before it is created.
@@ -214,4 +232,23 @@ impl Default for BodyMode {
     fn default() -> Self {
         BodyMode::Dynamic
     }
+}
+
+/// A contact event generated in the past frame.
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub struct ContactEvent<N: crate::PtReal> {
+    /// The other body tag.
+    other_body: PhysicsRigidBodyTag,
+    /// The other body entity.
+    other_entity: Option<Entity>,
+    /// The other body shape tag that is in contact.
+    other_shape_id: PhysicsShapeTag,
+    /// The actual body shape tag that is in contact.
+    shape_id: PhysicsShapeTag,
+    /// The contact normal on the local body.
+    contact_normal: Vector3<N>,
+    /// The contact location.
+    contact_location: Vector3<N>,
+    /// The generated impulse.
+    contact_impulse: Vector3<N>,
 }

--- a/src/servers/body_server.rs
+++ b/src/servers/body_server.rs
@@ -1,5 +1,5 @@
 use amethyst_core::ecs::Entity;
-use amethyst_core::math::{convert, one, zero, Isometry3, Vector3};
+use amethyst_core::math::{convert, one, Point3, Unit, zero, Isometry3, Vector3};
 
 use crate::objects::*;
 
@@ -140,10 +140,10 @@ pub trait RBodyPhysicsServerTrait<N: crate::PtReal> {
     /// The contact event are not guaranteed to arrive always in the same order.
     ///
     /// Default is 0.
-    fn set_max_contacts_count(&self, body_tag: PhysicsRigidBodyTag, max_contacts: usize);
+    fn set_contacts_to_report(&self, body_tag: PhysicsRigidBodyTag, count: usize);
 
     /// Get the maximum contacts count of this body.
-    fn max_contacts_count(&self, body_tag: PhysicsRigidBodyTag) -> usize;
+    fn contacts_to_report(&self, body_tag: PhysicsRigidBodyTag) -> usize;
 
     /// Fills the contacts array with the contacts events occurred in the last step.
     /// It doesn't fill more than the `max_contact_count` set.
@@ -179,6 +179,8 @@ pub struct RigidBodyDesc<N> {
     pub lock_rotation_y: bool,
     /// Lock body rotation along Z
     pub lock_rotation_z: bool,
+    /// Contacts to report.
+    pub contacts_to_report: usize,
 }
 
 /// Initialize the description with default values:
@@ -195,6 +197,7 @@ pub struct RigidBodyDesc<N> {
 /// lock_rotation_x: false,
 /// lock_rotation_y: false,
 /// lock_rotation_z: false,
+/// contacts_to_report: 0,
 /// ```
 impl<N: crate::PtReal> Default for RigidBodyDesc<N> {
     fn default() -> Self {
@@ -211,6 +214,7 @@ impl<N: crate::PtReal> Default for RigidBodyDesc<N> {
             lock_rotation_x: false,
             lock_rotation_y: false,
             lock_rotation_z: false,
+            contacts_to_report: 0,
         }
     }
 }
@@ -238,17 +242,25 @@ impl Default for BodyMode {
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct ContactEvent<N: crate::PtReal> {
     /// The other body tag.
-    other_body: PhysicsRigidBodyTag,
+    pub other_body: PhysicsRigidBodyTag,
     /// The other body entity.
-    other_entity: Option<Entity>,
-    /// The other body shape tag that is in contact.
-    other_shape_id: PhysicsShapeTag,
-    /// The actual body shape tag that is in contact.
-    shape_id: PhysicsShapeTag,
+    pub other_entity: Option<Entity>,
     /// The contact normal on the local body.
-    contact_normal: Vector3<N>,
-    /// The contact location.
-    contact_location: Vector3<N>,
+    pub contact_normal: Unit<Vector3<N>>,
+    /// The contact location in world space.
+    pub contact_location: Point3<N>,
     /// The generated impulse.
-    contact_impulse: Vector3<N>,
+    pub contact_impulse: Vector3<N>,
+}
+
+impl<N: crate::PtReal> Default for ContactEvent<N>{
+    fn default() -> Self{
+        ContactEvent {
+            other_body: PhysicsRigidBodyTag::U32(0),
+            other_entity: None,
+            contact_normal: Vector3::y_axis(),
+            contact_location: Point3::origin(),
+            contact_impulse: Vector3::zeros(),
+        }
+    }
 }

--- a/src/servers/mod.rs
+++ b/src/servers/mod.rs
@@ -10,7 +10,7 @@
 //! Is it possible to access them trough the `PhysicsWorld`.
 
 pub use area_server::{AreaDesc, AreaPhysicsServerTrait, OverlapEvent};
-pub use body_server::{BodyMode, RBodyPhysicsServerTrait, RigidBodyDesc};
+pub use body_server::{BodyMode, RBodyPhysicsServerTrait, RigidBodyDesc, ContactEvent};
 pub use joint_server::{JointDesc, JointPhysicsServerTrait, JointPosition};
 pub use shape_server::{ShapeDesc, ShapePhysicsServerTrait};
 pub use world_server::WorldPhysicsServerTrait;

--- a/src/servers/mod.rs
+++ b/src/servers/mod.rs
@@ -10,7 +10,7 @@
 //! Is it possible to access them trough the `PhysicsWorld`.
 
 pub use area_server::{AreaDesc, AreaPhysicsServerTrait, OverlapEvent};
-pub use body_server::{BodyMode, RBodyPhysicsServerTrait, RigidBodyDesc, ContactEvent};
+pub use body_server::{BodyMode, ContactEvent, RBodyPhysicsServerTrait, RigidBodyDesc};
 pub use joint_server::{JointDesc, JointPhysicsServerTrait, JointPosition};
 pub use shape_server::{ShapeDesc, ShapePhysicsServerTrait};
 pub use world_server::WorldPhysicsServerTrait;


### PR DESCRIPTION
# Add contact detection API.

When you need to read the contacts events generated by a Rigid Body, first of all you have to specify the max number of watchable contacts, that can be done in two ways:
- During Body creation by setting `contacts_to_report` to more than 0.
- Later using the API: `fn set_contacts_to_report(&self, body_tag: PhysicsRigidBodyTag, count: usize);`

Then by using the API `contact_events` you can retrieve the actual contact:
```rust
let mut v = Vec::new();
physics_world
    .rigid_body_server()
    .contact_events(body_tag.get(), &mut v);
    for contact in v {
        dbg!(contact);
    }
}
```

The `contact_events` API must be called each physics step to not miss any contact, and it returns a list of contacts where each contacts have the following info:
```rust
/// The other body tag.
pub other_body: PhysicsRigidBodyTag,
/// The other body entity.
pub other_entity: Option<Entity>,
/// The contact normal on the local body.
pub normal: Unit<Vector3<N>>,
/// The contact location in world space.
pub location: Point3<N>,
/// The generated impulse.
pub impulse: Vector3<N>,
```