### PR TITLE
update amethyst to 0.15.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amethyst_physics"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Andrea Catania <info@andreacatania.com>"]
 edition = "2018"
 repository = "https://github.com/AndreaCatania/amethyst_physics"
@@ -11,6 +11,6 @@ readme = "README.md"
 license = "MIT"
 
 [dependencies]
-amethyst_core = "0.10.0"
-amethyst_error = "0.5.0"
+amethyst_core = "0.15.3"
+amethyst_error = "0.15.3"
 log = "0.4.6"


### PR DESCRIPTION
Update amethyst to work with 0.15.3. :)

Without that, it's not working in amethyst `0.15.3`.
Btw, your example project `amethyst_physics_test` is faulty.
It's using `amethyst 0.13.2`, you forgot to `cargo update`. :)